### PR TITLE
Add sample env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for AutoStockMint
+OPENAI_API_KEY=your-openai-api-key
+DISCORD_BOT_TOKEN=your-discord-bot-token
+ADOBE_STOCK_USERNAME=your-adobe-stock-username
+ADOBE_STOCK_PASSWORD=your-adobe-stock-password

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ AI-powered automation system that generates stock images (via Midjourney), tags 
 - Optional: n8n, ffmpeg, Whisper
 
 ## Setup
+1. Copy `.env.example` to `.env` and fill in your API keys and credentials.


### PR DESCRIPTION
## Summary
- add `.env.example` placeholder for storing secrets
- mention environment file in README

## Testing
- `python app.py` *(fails: no display name due to missing DISPLAY environment)*

------
https://chatgpt.com/codex/tasks/task_e_687d362ceb6c83209934a01553992430