### PR TITLE
Improve UI with collapsible sidebar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,14 +10,14 @@
 <body class="bg-gray-900 text-white h-screen flex overflow-hidden">
 
 <!-- Sidebar -->
-<div id="sidebar" class="w-60 bg-gray-800 flex flex-col">
+<div id="sidebar" class="w-48 bg-gray-800 flex flex-col transition-all duration-300">
 
     <!-- Sidebar Header -->
     <div class="p-4 flex items-center justify-between border-b border-gray-700">
         <div class="text-xl font-bold flex items-center">
             <span class="mr-2">🎨</span> AutoStockMint
         </div>
-        <button onclick="toggleSidebarTabs()" class="text-white hover:text-gray-300">☰</button>
+        <button onclick="toggleSidebar()" class="text-white hover:text-gray-300">⏴</button>
     </div>
 
     <!-- Sidebar Tabs (toggle target) -->
@@ -34,7 +34,8 @@
 <div class="flex-1 flex flex-col">
 
     <!-- Header -->
-    <div class="flex items-center justify-end bg-gray-800 p-4 border-b border-gray-700">
+    <div class="flex items-center justify-between bg-gray-800 p-4 border-b border-gray-700">
+        <button id="openSidebarBtn" onclick="toggleSidebar()" class="text-white hover:text-gray-300 hidden">☰</button>
         <div class="relative">
             <button onclick="toggleDropdown()" class="bg-cyan-500 px-4 py-2 rounded">⚙️ Tools</button>
             <div id="dropdown" class="absolute right-0 mt-2 w-48 bg-gray-700 rounded hidden z-10">
@@ -83,9 +84,6 @@
         document.getElementById('dropdown').classList.toggle('hidden');
     }
 
-    function toggleSidebarTabs() {
-        document.getElementById('sidebarTabs').classList.toggle('hidden');
-    }
 
     function goToPage(page) {
         document.getElementById('mainPage').classList.add('hidden');

--- a/frontend/renderer.js
+++ b/frontend/renderer.js
@@ -1,6 +1,8 @@
 function toggleSidebar() {
     const sidebar = document.getElementById('sidebar');
+    const openBtn = document.getElementById('openSidebarBtn');
     sidebar.classList.toggle('hidden');
+    openBtn.classList.toggle('hidden');
 }
 
 function toggleDropdown() {
@@ -26,13 +28,3 @@ async function callAPI(path) {
     const json = await res.json();
     document.getElementById("result").innerText = json.message;
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-    const toggleBtn = document.getElementById('toggleBtn');
-    if (toggleBtn) {
-        toggleBtn.addEventListener('click', () => {
-            const tabs = document.getElementById('sidebarTabs');
-            tabs.classList.toggle('hidden');
-        });
-    }
-});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -10,3 +10,7 @@
 .btn:hover {
     background-color: #0097a7;
 }
+
+#sidebar {
+    transition: width 0.3s;
+}


### PR DESCRIPTION
## Summary
- tweak sidebar width and add collapse button
- show a button to reopen sidebar when hidden
- clean up unused code and add simple transition styles

## Testing
- `npm test` *(fails: Missing script)*
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687ef814bc9883208009f71016c88dd7